### PR TITLE
Add label-based trigger for Gemini PR review workflow

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -2,11 +2,12 @@ name: Gemini PR Review
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
 
 jobs:
   gemini_review:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'api-review')
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Trigger only when "api-review" is labeled on the PR